### PR TITLE
fix: config.yaml.example

### DIFF
--- a/package/heishamon/files/config.yaml.example
+++ b/package/heishamon/files/config.yaml.example
@@ -7,7 +7,7 @@ optionalPCB: false
 optionalQueryInterval: 5
 optionalSaveInterval: 60
 mqttServer: "127.0.0.1"
-mqttPort: "1883"
+mqttPort: 1883
 mqttLogin: ""
 mqttPass: ""
 mqttKeepalive: 60


### PR DESCRIPTION
Fix unmarshal error for the example config
```
config.go:66: yaml: unmarshal errors:
  line 10: cannot unmarshal !!str `1883` into int
```